### PR TITLE
Fix ARP table handling for non-numeric TTL values

### DIFF
--- a/napalm_panos/panos.py
+++ b/napalm_panos/panos.py
@@ -469,7 +469,7 @@ class PANOSDriver(NetworkDriver):  # pylint: disable=too-many-instance-attribute
             try:
                 entry["age"] = float(arp_item["ttl"])
             except ValueError:
-                entry["age"] = arp_item["ttl"]
+                entry["age"] = float(-1)
             arps.append(entry)
         return arps
 

--- a/napalm_panos/panos.py
+++ b/napalm_panos/panos.py
@@ -466,7 +466,10 @@ class PANOSDriver(NetworkDriver):  # pylint: disable=too-many-instance-attribute
             entry["interface"] = arp_item["interface"]
             entry["mac"] = arp_item["mac"]
             entry["ip"] = arp_item["ip"]
-            entry["age"] = float(arp_item["ttl"])
+            try:
+                entry["age"] = float(arp_item["ttl"])
+            except ValueError:
+                entry["age"] = arp_item["ttl"]
             arps.append(entry)
         return arps
 


### PR DESCRIPTION
- Updated the ARP table parsing to handle non-numeric "ttl" values that could not be converted to a float (e.g., "N/A").

- This change was made after encountering a TTL value of "N/A", which caused a ValueError and crashed my script.

- Wrapped the conversion in a try/except block to catch ValueError exceptions.

- If a non-numeric value is encountered, it is stored as a string instead of crashing the script.

- This ensures the script continues running even when encountering unexpected TTL values.