### PR TITLE
add port parameter to PanXapi initialization #127

### DIFF
--- a/napalm_panos/panos.py
+++ b/napalm_panos/panos.py
@@ -106,6 +106,7 @@ class PANOSDriver(NetworkDriver):  # pylint: disable=too-many-instance-attribute
             except KeyError:
                 pass
         self.api_key = optional_args.get("api_key", "")
+        self.port = optional_args.get("port")
 
     def open(self):
         """PANOS version of `open` method, see NAPALM for documentation."""
@@ -115,6 +116,7 @@ class PANOSDriver(NetworkDriver):  # pylint: disable=too-many-instance-attribute
             else:
                 self.device = pan.xapi.PanXapi(
                     hostname=self.hostname,
+                    port=self.port,
                     api_username=self.username,
                     api_password=self.password,
                 )


### PR DESCRIPTION
**Title:** Support custom HTTPS ports for Palo Alto devices in napalm-panos

**Description:**
This PR updates napalm-panos to allow Palo Alto devices that use non-standard HTTPS ports for management and API access.

**Impact:**
	•	Users can now manage Palo Alto devices using custom HTTPS ports.
	•	Prevents connection failures due to non-standard port usage.