### PR TITLE
Remove pkg_resources version parsing dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixed
+
+- #130 Avoid importing `pkg_resources` when loading the driver.
+
 ## 0.7.0 - 2025-06
 
 ### Fixed

--- a/napalm_panos/panos.py
+++ b/napalm_panos/panos.py
@@ -34,11 +34,8 @@ from napalm.base.helpers import mac as standardize_mac
 from napalm.base.utils.string_parsers import convert_uptime_string_seconds
 
 from netmiko import ConnectHandler
-from netmiko import __version__ as netmiko_version
 
 import pan.xapi
-
-from pkg_resources import parse_version
 
 import requests
 
@@ -91,12 +88,8 @@ class PANOSDriver(NetworkDriver):  # pylint: disable=too-many-instance-attribute
             "alt_host_keys": False,
             "alt_key_file": "",
             "ssh_config_file": None,
+            "allow_agent": False,
         }
-
-        if parse_version(netmiko_version) >= parse_version("2.0.0"):
-            netmiko_argument_map["allow_agent"] = False
-        elif parse_version(netmiko_version) >= parse_version("1.1.0"):
-            netmiko_argument_map["allow_agent"] = False
 
         # Build dict of any optional Netmiko args
         self.netmiko_optional_args = {}


### PR DESCRIPTION
## New Pull Request

Have you:
- [ ] Updated the README if necessary?
- [ ] Updated any configuration settings?
- [ ] Written a unit test?

## Change Notes

- remove the `pkg_resources.parse_version` import that prevents the driver from
  loading when `pkg_resources` is unavailable
- preserve `allow_agent` as an accepted Netmiko optional argument now that the
  supported dependency is already constrained to `netmiko = "^4.4.0"`
- record the fix in the changelog

## Justification

`napalm_panos.panos` imports `pkg_resources` at module load time, while recent
setuptools releases no longer provide that module. The only use was a Netmiko
version gate whose supported branches both add `allow_agent`; the current
package constraint makes that gate unnecessary.

Fixes #130

## Validation

- `git diff --check HEAD~1..HEAD`
- Not run locally
