### PR TITLE
Remove lxml dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ include = [
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
 napalm = "^5.0.0"
-lxml = "^5.0.0"
 pan-python = "*"
 netmiko = ">=4.4.0"
 requests-toolbelt = "*"


### PR DESCRIPTION
- Remove unused `lxml` dependency — `lxml` was declared in `pyproject.toml` but never imported
  or used anywhere in the codebase (`panos.py` uses the stdlib `xml.etree` module exclusively).
  The `^5.0.0` Poetry caret constraint was preventing installation alongside `lxml>=6.0.0`,
  blocking CVE remediation for dependent projects.
CVE Detail : https://nvd.nist.gov/vuln/detail/CVE-2026-41066