### PR TITLE
Update lxml dependency version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ include = [
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
 napalm = "^5.0.0"
-lxml = "^5.0.0"
+lxml = ">=5.0.0"
 pan-python = "*"
 netmiko = ">=4.4.0"
 requests-toolbelt = "*"


### PR DESCRIPTION
- Widen `lxml` dependency constraint from `^5.0.0` to `>=5.0.0` — the Poetry caret syntax was resolving to `>=5.0.0,<6.0.0`, blocking downstream projects from upgrading lxml to remediate CVEs requiring lxml>=6.0.0. The `napalm` core package uses lxml directly so the dependency is kept, only the upper bound is removed.